### PR TITLE
feat: Add simple snarkos-dev devShell for working on snarkOS/snarkVM repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         include:
           - command: build --print-build-logs --no-update-lock-file .#leo
           - command: develop --no-update-lock-file .#leo-dev
+          - command: develop --no-update-lock-file .#snarkos-dev
           - command: flake check --all-systems --no-update-lock-file
           - command: fmt -- --ci
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
       devShells = perSystemPkgs (pkgs: {
         leo-dev = pkgs.callPackage ./pkgs/leo-dev.nix { };
         leo-nightly-dev = pkgs.callPackage ./pkgs/leo-dev.nix { leo = pkgs.leo-rust-nightly; };
+        snarkos-dev = pkgs.callPackage ./pkgs/snarkos-dev.nix { };
         default = inputs.self.devShells.${pkgs.stdenv.hostPlatform.system}.leo-dev;
       });
 

--- a/pkgs/snarkos-dev.nix
+++ b/pkgs/snarkos-dev.nix
@@ -1,0 +1,16 @@
+{
+  cargo-nextest,
+  mkShell,
+  snarkos,
+}:
+mkShell {
+  inputsFrom = [
+    snarkos
+  ];
+  buildInputs = [
+    cargo-nextest
+  ];
+  env = {
+    inherit (snarkos) LIBCLANG_PATH;
+  };
+}


### PR DESCRIPTION
You could previously get pretty far with `nix develop .#snarkos`, but this also provides cargo-nextest.