### PR TITLE
feat: Provide nightly rustfmt to `leo-dev` and `snarkos-dev`

### DIFF
--- a/pkgs/leo-dev.nix
+++ b/pkgs/leo-dev.nix
@@ -1,8 +1,12 @@
 {
   leo,
   mkShell,
+  rust-bin,
   snarkos-testnet,
 }:
+let
+  rust-nightly = rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+in
 mkShell {
   inputsFrom = [
     leo
@@ -12,5 +16,6 @@ mkShell {
   ];
   env = {
     inherit (snarkos-testnet) LIBCLANG_PATH;
+    RUSTFMT = "${rust-nightly}/bin/rustfmt";
   };
 }

--- a/pkgs/snarkos-dev.nix
+++ b/pkgs/snarkos-dev.nix
@@ -1,8 +1,12 @@
 {
   cargo-nextest,
   mkShell,
+  rust-bin,
   snarkos,
 }:
+let
+  rust-nightly = rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+in
 mkShell {
   inputsFrom = [
     snarkos
@@ -12,5 +16,6 @@ mkShell {
   ];
   env = {
     inherit (snarkos) LIBCLANG_PATH;
+    RUSTFMT = "${rust-nightly}/bin/rustfmt";
   };
 }


### PR DESCRIPTION
Both the snarkVM and leo repos require the nightly `rustfmt` due to the use of nightly features in their `rustfmt.toml` files.

By setting the `RUSTFMT` env var, we can override the default formatter with the nightly one so that we no longer need to switch between devShells or add a special nightly fmt command.