### PR TITLE
fix: Include `lld` in snarkos-dev devShell

### DIFF
--- a/pkgs/snarkos-dev.nix
+++ b/pkgs/snarkos-dev.nix
@@ -1,5 +1,6 @@
 {
   cargo-nextest,
+  lld,
   mkShell,
   rust-bin,
   snarkos,
@@ -13,6 +14,7 @@ mkShell {
   ];
   buildInputs = [
     cargo-nextest
+    lld
   ];
   env = {
     inherit (snarkos) LIBCLANG_PATH;


### PR DESCRIPTION
It looks like `mkShell`'s `inputsFrom = [ snarkos ];` isn't picking up the linker, as that's provided by nix's stdenv and is not an explicit input (provided via buildInputs or nativeBuildInputs). As a result, trying to build anything in the snarkvm or snarkos repos currently fails with linker errors.

This PR provides `lld` and appears to address the linking issues.