### PR TITLE
fix: Move `lld` from the `snarkos-dev` devShell inputs to a `nativeBuildInput` on the pkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         include:
           - command: build --print-build-logs --no-update-lock-file .#leo
+          - command: build --print-build-logs --no-update-lock-file .#snarkos-testnet
           - command: develop --no-update-lock-file .#leo-dev
           - command: develop --no-update-lock-file .#snarkos-dev
           - command: flake check --all-systems --no-update-lock-file

--- a/pkgs/snarkos-dev.nix
+++ b/pkgs/snarkos-dev.nix
@@ -1,6 +1,5 @@
 {
   cargo-nextest,
-  lld,
   mkShell,
   rust-bin,
   snarkos,
@@ -14,7 +13,6 @@ mkShell {
   ];
   buildInputs = [
     cargo-nextest
-    lld
   ];
   env = {
     inherit (snarkos) LIBCLANG_PATH;

--- a/pkgs/snarkos.nix
+++ b/pkgs/snarkos.nix
@@ -3,6 +3,7 @@
   buildNoDefaultFeatures ? false,
   lib,
   libclang,
+  lld,
   makeRustPlatform,
   openssl,
   pkg-config,
@@ -33,6 +34,7 @@ rustPlatform.buildRustPackage {
   };
   nativeBuildInputs = [
     libclang
+    lld
     pkg-config
   ];
   buildInputs = [


### PR DESCRIPTION
Follow-up to #4.

Rather than just ensuring `lld` is present for the snarkos-dev devShell, this also makes sure `lld` is being used as the linker for the `snarkos` and `snarkos-testnet` packages more generally.

Note that we still get the `lld` input in `snarkos-dev`, just that now we receive it via `inputsFrom` rather than adding it explicitly.

Also added a job to build `snarkos-testnet` specifically to make sure it works.