### PR TITLE
feat: Provide runtime lib paths for openssl, zlib to snarkos devShell

### DIFF
--- a/pkgs/snarkos-dev.nix
+++ b/pkgs/snarkos-dev.nix
@@ -15,7 +15,7 @@ mkShell {
     cargo-nextest
   ];
   env = {
-    inherit (snarkos) LIBCLANG_PATH ROCKSDB_LIB_DIR;
+    inherit (snarkos) LIBCLANG_PATH ROCKSDB_LIB_DIR LD_LIBRARY_PATH;
     RUSTFMT = "${rust-nightly}/bin/rustfmt";
   };
 }

--- a/pkgs/snarkos.nix
+++ b/pkgs/snarkos.nix
@@ -10,6 +10,7 @@
   rocksdb,
   rust-bin,
   src,
+  zlib,
 }:
 let
   rust = rust-bin.fromRustupToolchainFile "${src}/rust-toolchain.toml";
@@ -46,4 +47,9 @@ rustPlatform.buildRustPackage {
   LIBCLANG_PATH = lib.makeLibraryPath [ libclang ];
   # Dynamically link to rocksdb.
   ROCKSDB_LIB_DIR = lib.makeLibraryPath [ rocksdb ];
+  # Runtime library path for dynamically linked libraries.
+  LD_LIBRARY_PATH = lib.makeLibraryPath [
+    openssl
+    zlib
+  ];
 }


### PR DESCRIPTION
These are required for running `cargo test` in the `snarkvm` repo - there must be some test-feature-gated use of these libs there.