### PR TITLE
feat: Update leo-src flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "leo-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768314463,
-        "narHash": "sha256-536gUDRAqZcxeE005vWbhhERvnwCIjeJgdI1xHbTuRA=",
+        "lastModified": 1770938225,
+        "narHash": "sha256-RB5kJvxWJnBFLvmwPVAd7XEozBUtosmBkQO8HxphENc=",
         "owner": "provablehq",
         "repo": "leo",
-        "rev": "f118eaf482544e201c8c73bd9e6ead591df49f36",
+        "rev": "7d36db36b3aa1484188aee9079a1f939b2763acb",
         "type": "github"
       },
       "original": {

--- a/pkgs/leo.nix
+++ b/pkgs/leo.nix
@@ -17,7 +17,12 @@ rustPlatform.buildRustPackage {
   pname = "leo";
   version = manifest.package.version;
   src = src;
-  cargoLock.lockFile = "${src}/Cargo.lock";
+  cargoLock = {
+    lockFile = "${src}/Cargo.lock";
+    outputHashes = {
+      "snarkvm-4.4.0" = "sha256-JyRkTFGIv/8LjHMCns/FSAwxbN5Y2uhH+zkoJOGjkDU=";
+    };
+  };
   nativeBuildInputs = [
     pkg-config
   ];


### PR DESCRIPTION
Includes new `leo devnode` support.

Edit: I think this means we no longer need `snarkos-testnet` input in the leo-dev devShell, now that tests use `leo devnode`, though I'll leave it in for now just in case.