### PR TITLE
feat: Update flake inputs, update for leo workspace refactor

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "leo-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1770938225,
-        "narHash": "sha256-RB5kJvxWJnBFLvmwPVAd7XEozBUtosmBkQO8HxphENc=",
+        "lastModified": 1772597215,
+        "narHash": "sha256-R68g3swxZTVrIS/i5GmVlWI4h1DcRbWtk1QntN+2AwY=",
         "owner": "provablehq",
         "repo": "leo",
-        "rev": "7d36db36b3aa1484188aee9079a1f939b2763acb",
+        "rev": "b9be31562a983102a849582b1fa9b89828f1b99a",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768305791,
-        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
+        "lastModified": 1772542754,
+        "narHash": "sha256-WGV2hy+VIeQsYXpsLjdr4GvHv5eECMISX1zKLTedhdg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "rev": "8c809a146a140c5c8806f13399592dbcb1bb5dc4",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1768445213,
-        "narHash": "sha256-y0BglISgDr61vvdb35m0O4npuqh1pojlBNDILo9j8AI=",
+        "lastModified": 1772679930,
+        "narHash": "sha256-FxYmdacqrdDVeE9QqZKTIpNLjv2B8GSKssgwlZuTR98=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "1cd63408e71cc0e6a89ff2cb7c4107214e2523cc",
+        "rev": "9b741db17141331fdb26270a1b66b81be8be9edd",
         "type": "github"
       },
       "original": {

--- a/pkgs/leo.nix
+++ b/pkgs/leo.nix
@@ -10,17 +10,18 @@ let
     cargo = rust;
     rustc = rust;
   };
-  manifestPath = "${src}/Cargo.toml";
+  buildAndTestSubdir = "crates/leo";
+  manifestPath = "${src}/${buildAndTestSubdir}/Cargo.toml";
   manifest = builtins.fromTOML (builtins.readFile manifestPath);
 in
 rustPlatform.buildRustPackage {
   pname = "leo";
   version = manifest.package.version;
-  src = src;
+  inherit buildAndTestSubdir src;
   cargoLock = {
     lockFile = "${src}/Cargo.lock";
     outputHashes = {
-      "snarkvm-4.4.0" = "sha256-JyRkTFGIv/8LjHMCns/FSAwxbN5Y2uhH+zkoJOGjkDU=";
+      "snarkvm-4.4.0" = "sha256-d6gDwIXUMAenrXtOMSapDlaPp6WSXzdMPAEWiuXD5B0=";
     };
   };
   nativeBuildInputs = [


### PR DESCRIPTION
All flake inputs have been updated. This includes leo-src which depends on rust 1.93, which we can now pull via the updated rust-overlay input.

The main leo bin crate is now in a subdirectory, so we now use `buildAndTestSubdir`.