### PR TITLE
Add tree-sitter-leo grammar package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -54,7 +54,8 @@
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay",
         "snarkos-src": "snarkos-src",
-        "systems": "systems"
+        "systems": "systems",
+        "tree-sitter-leo-src": "tree-sitter-leo-src"
       }
     },
     "rust-overlay": {
@@ -104,6 +105,23 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "tree-sitter-leo-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1774984662,
+        "narHash": "sha256-FFttXR1l65sGkq1SJ/vEveDgRO+gcS9oOD1NFSv5wRA=",
+        "owner": "provablehq",
+        "repo": "leo",
+        "rev": "d9207de49e0d5fe938e61110f0a917e5f5c00b9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "provablehq",
+        "ref": "v4.0.0",
+        "repo": "leo",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,10 @@
       url = "github:provablehq/leo";
       flake = false;
     };
+    tree-sitter-leo-src = {
+      url = "github:provablehq/leo/v4.0.0";
+      flake = false;
+    };
     snarkos-src = {
       url = "github:provablehq/snarkos/v4.6.0";
       flake = false;
@@ -60,6 +64,19 @@
               src = inputs.snarkos-src;
               buildFeatures = [ "test_network" ];
             };
+
+            tree-sitter-grammars = prev.tree-sitter-grammars // {
+              # Tree-sitter grammar for Leo syntax highlighting.
+              tree-sitter-leo = prev.tree-sitter.buildGrammar {
+                language = "leo";
+                version = "4.0.0";
+                src = inputs.tree-sitter-leo-src;
+                location = "tree-sitter";
+              };
+            };
+
+            # Flat alias for easy access alongside inclusion in tree-sitter-grammars.
+            tree-sitter-leo = final.tree-sitter-grammars.tree-sitter-leo;
           };
       };
 
@@ -68,6 +85,7 @@
         leo-rust-nightly = pkgs.leo-rust-nightly;
         snarkos = pkgs.snarkos;
         snarkos-testnet = pkgs.snarkos-testnet;
+        tree-sitter-leo = pkgs.tree-sitter-leo;
         default = pkgs.leo;
       });
 


### PR DESCRIPTION
## Summary
- Adds a dedicated `tree-sitter-leo-src` flake input pinned to `ProvableHQ/leo@v4.0.0`
- Builds the Leo Tree-sitter grammar from the top-level `tree-sitter/` directory in the Leo repo
- Exposes the grammar via `tree-sitter-grammars.tree-sitter-leo`
- Keeps a flat `tree-sitter-leo` alias for direct consumption from `leo.nix`

## Notes
- This PR packages the Tree-sitter grammar only
- The source is pinned to the Leo `v4.0.0` tag rather than a moving `main` revision